### PR TITLE
:memo: fix bug of non-existing bounding box avoidance

### DIFF
--- a/bdd_data/label2det.py
+++ b/bdd_data/label2det.py
@@ -22,7 +22,7 @@ def label2det(label):
             if 'box2d' not in obj:
                 continue
             xy = obj['box2d']
-            if xy['x1'] >= xy['x2'] and xy['y1'] >= xy['y2']:
+            if xy['x1'] >= xy['x2'] or xy['y1'] >= xy['y2']:
                 continue
             box = {'name': label['name'],
                    'timestamp': frame['timestamp'],


### PR DESCRIPTION
I think the there exists a logic bug judging when to avoid non-existing bounding box. 