### PR TITLE
set a Path.LINETO when Path.CURVE4 in the end of codes list

### DIFF
--- a/bdd_data/show_labels.py
+++ b/bdd_data/show_labels.py
@@ -381,7 +381,10 @@ class LabelViewer(object):
 
         if closed:
             points.append(points[0])
-            codes.append(Path.CLOSEPOLY)
+            if codes[-1] == 4:
+                codes.append(Path.LINETO)
+            else:
+                codes.append(Path.CLOSEPOLY)
 
         if color is None:
             color = random_color()


### PR DESCRIPTION
There is a bug to show label when control point in the end of whole closed polygon.  Just like the image below. 
![微信截图_20191219121033](https://user-images.githubusercontent.com/11882730/71144326-96c23d80-2258-11ea-957e-8b6cd0be6a7a.png)

After fix that bug : 
![微信截图_20191219121216](https://user-images.githubusercontent.com/11882730/71144386-d1c47100-2258-11ea-9323-70627417a866.png)
